### PR TITLE
Add game command and refactor ratewaifu

### DIFF
--- a/bot/config.json
+++ b/bot/config.json
@@ -15,5 +15,6 @@
 	"weather_api_key": "",
 	"osu_api_key": "",
 	"imgur_client_id": "",
-	"banned_server_ids": [""]
+	"banned_server_ids": [""],
+	"allowChangeGame": true
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"osu-api": "*",
 		"chalk": "*",
 		"entities": ">=1.1.1",
-		"winston": ">=2.2.0"
+		"winston": ">=2.2.0",
+		"jsonfile": "*"
 	}
 }


### PR DESCRIPTION
Added game command:
-if "allowChangeGame" is false, do nothing
-if suffix is not empty, change played game to suffix
-if suffix evaluates to false, change played game to null

refactored ratewaifu:
-the command now uses the centralized waifus.json file for all ratings
and saves to the file after any new rating is generated
-the multiple rating generation commands have been refactored to be
generateWaifuRating()
-removed waifu search function

Other:
-package dependency "jsonfile" added
