### PR TITLE
Optionally load bluebird promise library if present

### DIFF
--- a/Mirai.js
+++ b/Mirai.js
@@ -1,6 +1,12 @@
 if (parseFloat(process.versions.node) < 6)
 	throw new Error('Incompatible node version. Install Node 6 or higher.');
 
+try {
+	Promise = require("bluebird");
+} catch(err) {
+	Promise = global.Promise;
+}
+
 var reload          = require('require-reload')(require),
 	fs              = require('fs'),
 	Eris            = require('eris'),

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
 		"jsdoc-parse": "^1.2.7",
 		"minami": "^1.1.1",
 		"eslint": "*"
+	},
+	"optionalDependencies": {
+		"bluebird": "3.4.6"
 	}
 }


### PR DESCRIPTION
Load bluebird library if installed.  See why we should use [bluebird](https://codedump.io/share/BsUNY5VbtUg/1/are-there-still-reasons-to-use-promise-libraries-like-q-or-bluebird-now-that-we-have-es6-promises)
