### PR TITLE
Allow the use of fallback commands

### DIFF
--- a/utils/Command.js
+++ b/utils/Command.js
@@ -12,6 +12,7 @@
 * @prop {Boolean} hidden If the command should be hidden from help.
 * @prop {Boolean} ownerOnly If the command can only be used by a bot admin.
 * @prop {Boolean} guildOnly If the command can only be used in a guild.
+* @prop {Boolean} fallback If this command should be executed when there are no other matching commands.
 * @prop {String} requiredPermission The permission needed to use the command.
 * @prop {Number} timesUsed How many times the command has been used.
 * @prop {Set} usersOnCooldown Users that are still on cooldown.
@@ -33,6 +34,7 @@ class Command {
 	* @arg {Boolean} [cmd.hidden=false]
 	* @arg {Boolean} [cmd.ownerOnly=false]
 	* @arg {Boolean} [cmd.guildOnly=false]
+	* @arg {Boolean} [cmd.fallback=false]
 	* @arg {String} [cmd.requiredPermission=null] A Discord [permission]{@link https://abal.moe/Eris/reference.html}
 	* @arg {Function} [cmd.initialize] A function that runs at creation and is passed the client.
 	* @arg {Function} [cmd.destroy] A function that runs at destruction.
@@ -51,6 +53,7 @@ class Command {
 		this.hidden = !!cmd.hidden;
 		this.ownerOnly = !!cmd.ownerOnly;
 		this.guildOnly = !!cmd.guildOnly;
+		this.fallback = !!cmd.fallback;
 		this.requiredPermission = cmd.requiredPermission || null;
 		this.timesUsed = 0;
 		this.usersOnCooldown = new Set();

--- a/utils/CommandManager.js
+++ b/utils/CommandManager.js
@@ -66,8 +66,6 @@ class CommandManager {
 	*/
 	processCommand(bot, msg, config, settingsManager) {
 		let name = msg.content.replace(this.prefix, '').split(/ |\n/)[0];
-		if (name.toLowerCase() === "help")
-			return this.help(bot, msg, msg.content.replace(this.prefix + name, '').trim());
 		let command = this.checkForMatch(name.toLowerCase());
 		if (command !== null) {
 			if (msg.channel.guild !== undefined && !msg.channel.permissionsOf(msg.author.id).has('manageChannels') && settingsManager.isCommandIgnored(this.prefix, command.name, msg.channel.guild.id, msg.channel.id, msg.author.id) === true)
@@ -75,6 +73,8 @@ class CommandManager {
 			let suffix = msg.content.replace(this.prefix + name, '').trim();
 			this.logger.logCommand(msg.channel.guild === undefined ? null : msg.channel.guild.name, msg.author.username, this.prefix + command.name, msg.cleanContent.replace(this.prefix + name, '').trim());
 			return command.execute(bot, msg, suffix, config, settingsManager, this.logger);
+		} else if (name.toLowerCase() === "help") {
+			return this.help(bot, msg, msg.content.replace(this.prefix + name, '').trim());
 		}
 	}
 

--- a/utils/CommandManager.js
+++ b/utils/CommandManager.js
@@ -48,7 +48,6 @@ class CommandManager {
 								let command = new Command(name, this.prefix, reload(this.directory + name + '.js'), bot, config);
 								this.commands[name] = command;
 								settingsManager.commandList[this.prefix].push(name);
-
 								if (command.fallback) {
 									this.fallbackCommands.push(command);
 								}
@@ -57,7 +56,6 @@ class CommandManager {
 							}
 						}
 					}
-
 					resolve();
 				}
 			});

--- a/utils/CommandManager.js
+++ b/utils/CommandManager.js
@@ -23,6 +23,7 @@ class CommandManager {
 		this.prefix = prefix;
 		this.directory = `${__dirname}/../${dir}`;
 		this.commands = {};
+		this.fallbackCommands = [];
 		this.logger = new _Logger(config.logTimestamp, color);
 	}
 
@@ -44,13 +45,19 @@ class CommandManager {
 						if (name.endsWith('.js')) {
 							try {
 								name = name.replace(/\.js$/, '');
-								this.commands[name] = new Command(name, this.prefix, reload(this.directory + name + '.js'), bot, config);
+								let command = new Command(name, this.prefix, reload(this.directory + name + '.js'), bot, config);
+								this.commands[name] = command;
 								settingsManager.commandList[this.prefix].push(name);
+
+								if (command.fallback) {
+									this.fallbackCommands.push(command);
+								}
 							} catch (e) {
 								this.logger.error(`${e}\n${e.stack}`, 'Error loading command ' + name);
 							}
 						}
 					}
+
 					resolve();
 				}
 			});
@@ -67,15 +74,34 @@ class CommandManager {
 	processCommand(bot, msg, config, settingsManager) {
 		let name = msg.content.replace(this.prefix, '').split(/ |\n/)[0];
 		let command = this.checkForMatch(name.toLowerCase());
+		let suffix = msg.content.replace(this.prefix + name, '').trim();
 		if (command !== null) {
 			if (msg.channel.guild !== undefined && !msg.channel.permissionsOf(msg.author.id).has('manageChannels') && settingsManager.isCommandIgnored(this.prefix, command.name, msg.channel.guild.id, msg.channel.id, msg.author.id) === true)
 				return;
-			let suffix = msg.content.replace(this.prefix + name, '').trim();
-			this.logger.logCommand(msg.channel.guild === undefined ? null : msg.channel.guild.name, msg.author.username, this.prefix + command.name, msg.cleanContent.replace(this.prefix + name, '').trim());
+			this.logCommand(msg, command.name, name);
 			return command.execute(bot, msg, suffix, config, settingsManager, this.logger);
 		} else if (name.toLowerCase() === "help") {
 			return this.help(bot, msg, msg.content.replace(this.prefix + name, '').trim());
+		} else if (this.fallbackCommands.length > 0) {
+			this.logCommand(msg, name, name);
+			let commandResults = [];
+			for (let i = 0; i < this.fallbackCommands.length; ++i) {
+				let command = this.fallbackCommands[i];
+				commandResults.push(command.execute(bot, msg, suffix, config, settingsManager, this.logger));
+			}
+
+			return commandResults;
 		}
+	}
+
+	/**
+	* Logs a command
+	* @arg {Eris.Message} msg The message containing the command to log.
+	* @arg {String} commandNameToLog The command name that should appear in the log.
+	* @arg {String} commandNameEntered The actual command name that the user typed and which is contained in msg.
+	*/
+	logCommand(msg, commandNameToLog, commandNameEntered) {
+		this.logger.logCommand(msg.channel.guild === undefined ? null : msg.channel.guild.name, msg.author.username, this.prefix + commandNameToLog, msg.cleanContent.replace(this.prefix + commandNameEntered, '').trim());
 	}
 
 	/**


### PR DESCRIPTION
Hello again :) I hope you might consider pulling a little larger change this time.
 
This change allows commands to be specified as fallback commands. They will be executed when a user uses the command prefix, but does not specify a valid command.
 
For example, if you make the about.js command a fallback command, then entering "]wgrorgrg" or "]" will execute the about.js command.
 
My use case for this is doing translation. I want "k!en-de car" to translate "car" from English into German. But I do not want to make an "en-de" command because I would have to do that for all possible combinations of languages (that would mean I'd need number_of_supported_languages^2 commands). So I make a hidden fallback "translate" command.
 
Testing:
* With no fallback commands:
  1. "]about" displays the about dialog. Log: "[server] >> [name] > ]about"
  2. "]fwrgg" does nothing, logs nothing.
  3. "]" does nothing, logs nothing.
  4. "not_command" does nothing, logs nothing.
* After making about.js a fallback command:
  1. "]about" displays the about dialog. Log: "[server] >> [name] > ]about"
  2. "]teheth" displays the about dialog. Log: "[server] >> [name] > ]teheth"
  3. "]" displays the about dialog. Log: "[server] >> [name] > ]"
  4. "not_command" does nothing, logs nothing.
* After making coinflip.js also a fallback command:
  1. "]about" displays the about dialog. Log: "[server] >> [name] > ]about"
  2. "]teheth" displays the about dialog and flips a coin. Log: "[server] >> [name] > ]teheth"
  3. "]" displays the about dialog and flips a coin. Log: "[server] >> [name] > ]"
  4. "not_command" does nothing, logs nothing.